### PR TITLE
[2/3] Add "Accept all files" option for incoming files

### DIFF
--- a/src/com/android/bluetooth/opp/BluetoothOppObexServerSession.java
+++ b/src/com/android/bluetooth/opp/BluetoothOppObexServerSession.java
@@ -54,6 +54,7 @@ import android.os.Process;
 import android.os.SystemProperties;
 import android.provider.ContactsContract.Contacts;
 import android.provider.ContactsContract.Profile;
+import android.provider.Settings;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
 
@@ -257,6 +258,8 @@ public class BluetoothOppObexServerSession extends ServerRequestHandler implemen
         }
         boolean isWhitelisted = BluetoothOppManager.getInstance(mContext).
                 isWhitelisted(destination);
+        boolean isAcceptAllFilesEnabled = Settings.System.getInt(mContext.getContentResolver(),
+                Settings.System.BLUETOOTH_ACCEPT_ALL_FILES, 0) == 1;
 
         try {
             boolean pre_reject = false;
@@ -279,47 +282,65 @@ public class BluetoothOppObexServerSession extends ServerRequestHandler implemen
                 obexResponse = ResponseCodes.OBEX_HTTP_BAD_REQUEST;
             }
 
-            if (!pre_reject) {
-                /* first we look for Mimetype in Android map */
-                String extension, type;
-                int dotIndex = name.lastIndexOf(".");
-                if (dotIndex < 0 && mimeType == null) {
-                    if (D) Log.w(TAG, "There is no file extension or mime type," +
-                            "reject the transfer");
-                    pre_reject = true;
-                    obexResponse = ResponseCodes.OBEX_HTTP_BAD_REQUEST;
-                } else {
-                    extension = name.substring(dotIndex + 1).toLowerCase();
-                    MimeTypeMap map = MimeTypeMap.getSingleton();
-                    type = map.getMimeTypeFromExtension(extension);
-                    if (V) Log.v(TAG, "Mimetype guessed from extension " + extension + " is " + type);
-                    if (type != null) {
-                        mimeType = type;
-
+            if (!isAcceptAllFilesEnabled) {
+                if (!pre_reject) {
+                    /* first we look for Mimetype in Android map */
+                    String extension, type;
+                    int dotIndex = name.lastIndexOf(".");
+                    if (dotIndex < 0 && mimeType == null) {
+                        if (D)
+                            Log.w(TAG, "There is no file extension or mime type," +
+                                    "reject the transfer. File name:" + name);
+                        pre_reject = true;
+                        obexResponse = ResponseCodes.OBEX_HTTP_BAD_REQUEST;
                     } else {
-                        if (mimeType == null) {
-                            if (D) Log.w(TAG, "Can't get mimetype, reject the transfer");
-                            pre_reject = true;
-                            obexResponse = ResponseCodes.OBEX_HTTP_UNSUPPORTED_TYPE;
+                        extension = name.substring(dotIndex + 1).toLowerCase();
+                        MimeTypeMap map = MimeTypeMap.getSingleton();
+                        type = map.getMimeTypeFromExtension(extension);
+                        if (V)
+                            Log.v(TAG, "Mimetype guessed from extension " + extension + " is "
+                                    + type);
+                        if (type != null) {
+                            mimeType = type;
+
+                        } else {
+                            if (mimeType == null) {
+                                if (D)
+                                    Log.w(TAG, "Can't get mimetype, reject the transfer");
+                                pre_reject = true;
+                                obexResponse = ResponseCodes.OBEX_HTTP_UNSUPPORTED_TYPE;
+                            }
+                        }
+                        if (mimeType != null) {
+                            mimeType = mimeType.toLowerCase();
                         }
                     }
-                    if (mimeType != null) {
-                        mimeType = mimeType.toLowerCase();
-                    }
                 }
-            }
 
-            // Reject policy: anything outside the "white list" plus unspecified
-            // MIME Types. Also reject everything in the "black list".
-            if (!pre_reject
-                    && (mimeType == null
-                            || (!isWhitelisted && !Constants.mimeTypeMatches(mimeType,
-                                    Constants.ACCEPTABLE_SHARE_INBOUND_TYPES))
-                            || Constants.mimeTypeMatches(mimeType,
-                                    Constants.UNACCEPTABLE_SHARE_INBOUND_TYPES))) {
-                if (D) Log.w(TAG, "mimeType is null or in unacceptable list, reject the transfer");
-                pre_reject = true;
-                obexResponse = ResponseCodes.OBEX_HTTP_UNSUPPORTED_TYPE;
+                // Reject policy: anything outside the "white list" plus
+                // unspecified MIME Types.
+                // Also reject everything in the "black list".
+                if (!pre_reject
+                        && (mimeType == null
+                                || (!isWhitelisted && !Constants.mimeTypeMatches(mimeType,
+                                        Constants.ACCEPTABLE_SHARE_INBOUND_TYPES))
+                                || Constants.mimeTypeMatches(mimeType,
+                                Constants.UNACCEPTABLE_SHARE_INBOUND_TYPES))) {
+                    if (D)
+                        Log.w(TAG,
+                                "mimeType is null or in unacceptable list, reject the transfer. mimeType is "
+                                        + ((mimeType == null) ? "null" : mimeType));
+                    pre_reject = true;
+                    obexResponse = ResponseCodes.OBEX_HTTP_UNSUPPORTED_TYPE;
+                }
+            } else {
+                if (D)
+                    Log.i(TAG, "isAcceptAllFilesEnabled == true, skipped check of mime type");
+                if (mimeType == null) {
+                    mimeType = "*/*";
+                    if (D)
+                        Log.i(TAG, "mimeType is null. Fixed to */*");
+                }
             }
 
             if (pre_reject && obexResponse != ResponseCodes.OBEX_HTTP_OK) {


### PR DESCRIPTION
- Renamed some variable.
- Re-organized the comment.
- Reworded the commit message.
  
  This patch will make OBEX server respect the "accept all files"
  setting. If enabled, it will skip checking MIME type of incoming file,
  so the file types not present in whitelist can be accepted.
  Blacklist will be ignored as well. (There's nothing in blacklist in fact)
  If it's disabled, the check will be performed as usual.

Change-Id: I0ad02813bbd123c4caa2f1eaadf5995399fae598
